### PR TITLE
Fixed gurobi bug

### DIFF
--- a/examples/solver.jl
+++ b/examples/solver.jl
@@ -5,7 +5,7 @@ This function returns the JuMP optimizer with its appropriate attributes, based 
 user-defined inputs in `params` dictionary.  
 """
 function get_solver(params::Dict{String,Any})
-    optimizers_list = ["cplex", "cbc", "ipopt", "juniper", "alpine", "glpk"]
+    optimizers_list = ["gurobi", "cplex", "cbc", "ipopt", "juniper", "alpine", "glpk"]
 
     # Optimizer
     if !("optimizer" in keys(params))


### PR DESCRIPTION
This is a small thing I just noticed. In the solver.jl file in the examples, you have optimizers_list = ["cplex", "cbc", "ipopt", "juniper", "alpine", "glpk"] and gurobi is not in this. This results in an error when using gurobi (ERROR: LoadError: UndefVarError: Memento not defined). If you just add "gurobi" to the beginning of that list it works (since it an option in the if/else branching later).