### PR TITLE
Updating naming for unparameterized gates

### DIFF
--- a/examples/2qubit_gates.jl
+++ b/examples/2qubit_gates.jl
@@ -63,7 +63,7 @@ function test_controlled_V()
     "num_qubits" => 2, 
     "depth" => 7,    
 
-    "elementary_gates" => ["H1", "H2", "T1", "T2", "Tdagger1", "cnot_12", "cnot_21"],
+    "elementary_gates" => ["H_1", "H_2", "T_1", "T_2", "Tdagger_1", "cnot_12", "cnot_21"],
     "target_gate" => QCO.CVGate(),
     
     "objective" => "minimize_depth", 
@@ -168,7 +168,7 @@ function test_magic_M_using_SHCnot()
         "num_qubits" => 2, 
         "depth" => 5,    
     
-        "elementary_gates" => ["S1", "S2", "H1", "H2", "cnot_12", "cnot_21", "Identity"], 
+        "elementary_gates" => ["S_1", "S_2", "H_1", "H_2", "cnot_12", "cnot_21", "Identity"], 
         "target_gate" => QCO.MGate(),
            
         "objective" => "minimize_depth", 
@@ -218,7 +218,7 @@ function test_cnot_21()
     "num_qubits" => 2, 
     "depth" => 5,    
 
-    "elementary_gates" => ["H1", "H2", "Identity", "cnot_12"],  
+    "elementary_gates" => ["H_1", "H_2", "Identity", "cnot_12"],  
     "target_gate" => QCO.CNotRevGate(),
  
     "objective" => "minimize_depth", 
@@ -341,7 +341,7 @@ function test_HCoinGate()
         "num_qubits" => 2, 
         "depth" => 14,    
     
-        "elementary_gates" => ["Y1", "Y2", "Z1", "Z2", "T2", "Tdagger1", "Sdagger1", "SX1", "SXdagger2", "cnot_21", "cnot_12", "Identity"], 
+        "elementary_gates" => ["Y_1", "Y_2", "Z_1", "Z_2", "T_2", "Tdagger_1", "Sdagger_1", "SX_1", "SXdagger_2", "cnot_21", "cnot_12", "Identity"], 
         "target_gate" => -QCO.HCoinGate(),   
                   
         "objective" => "minimize_depth", 

--- a/examples/3qubit_gates.jl
+++ b/examples/3qubit_gates.jl
@@ -18,7 +18,7 @@ function test_RX_on_q3()
     "decomposition_type" => "exact",
     
     "optimizer" => "cplex",
-    "optimizer_presolve" => false, #turning this true will give infeasiblity in CPLEX - most probably a bug in CPLEX's presolve
+    "optimizer_presolve" => false, #turning this true will give infeasiblity in cplex - most probably a bug in cplex's presolve
     
     )
 
@@ -35,7 +35,7 @@ function test_toffoli()
     "num_qubits" => 3, 
     "depth" => 15,    
 
-    "elementary_gates" => ["T1", "T2", "T3", "H3", "cnot_12", "cnot_13", "cnot_23", "Tdagger2", "Tdagger3", "Identity"], 
+    "elementary_gates" => ["T_1", "T_2", "T_3", "H_3", "cnot_12", "cnot_13", "cnot_23", "Tdagger_2", "Tdagger_3", "Identity"], 
     "target_gate" => QCO.ToffoliGate(),
     "input_circuit" => toffoli_circuit(),
     
@@ -53,20 +53,20 @@ end
 
 function toffoli_circuit()
     # [(depth, gate)]
-    return [(1, "H3"), 
+    return [(1, "H_3"), 
         (2, "cnot_23"), 
-        (3, "Tdagger3"), 
+        (3, "Tdagger_3"), 
         (4, "cnot_13"), 
-        (5, "T3"), 
+        (5, "T_3"), 
         (6, "cnot_23"), 
-        (7, "Tdagger3"), 
+        (7, "Tdagger_3"), 
         (8, "cnot_13"), 
-        (9, "T2"), 
-        (10, "T3"), 
+        (9, "T_2"), 
+        (10, "T_3"), 
         (11, "cnot_12"), 
-        (12, "H3"), 
-        (13, "T1"), 
-        (14, "Tdagger2"),
+        (12, "H_3"), 
+        (13, "T_1"), 
+        (14, "Tdagger_2"),
         (15, "cnot_12")
         ] 
 end

--- a/examples/ex1.jl
+++ b/examples/ex1.jl
@@ -13,9 +13,9 @@ include("3qubit_gates.jl")
 function input_circuit()
          # [(depth, gate)]
     return [(1, "cnot_21"), 
-            (2, "S1"), 
-            (3, "H2"), 
-            (4, "S2")
+            (2, "S_1"), 
+            (3, "H_2"), 
+            (4, "S_2")
             ]
 end
 
@@ -38,8 +38,8 @@ params = Dict{String, Any}(
 "depth" => 4,
 
 "elementary_gates" => ["U3", "cnot_12", "Identity"],
-# "elementary_gates" => ["T1", "T2", "T3", "H3", "cnot_12", "cnot_13", "cnot_23", "Tdagger2", "Tdagger3", "Identity"],
-# "elementary_gates" => ["S1", "S2", "H1", "H2", "cnot_12", "cnot_21", "Identity"],
+# "elementary_gates" => ["T_1", "T_2", "T_3", "H_3", "cnot_12", "cnot_13", "cnot_23", "Tdagger_2", "Tdagger_3", "Identity"],
+# "elementary_gates" => ["S_1", "S_2", "H_1", "H_2", "cnot_12", "cnot_21", "Identity"],
 
 "target_gate" => QCO.CZGate(),
 

--- a/src/data.jl
+++ b/src/data.jl
@@ -460,64 +460,64 @@ function get_full_sized_gate(input::String, num_qubits::Int64; matrix = nothing,
         Memento.error(_LOGGER, "Gates with greater than 3 qubits are not currently supported")
     end
     
-    if input == "H1"
+    if input == "H_1"
         return QCO.kron_single_gate(num_qubits, QCO.HGate(), "q1")
 
-    elseif input == "H2"
+    elseif input == "H_2"
         return QCO.kron_single_gate(num_qubits, QCO.HGate(), "q2")
 
-    elseif input == "T1"
+    elseif input == "T_1"
         return QCO.kron_single_gate(num_qubits, QCO.TGate(), "q1")
 
-    elseif input == "T2"
+    elseif input == "T_2"
         return QCO.kron_single_gate(num_qubits, QCO.TGate(), "q2")
 
-    elseif input == "Tdagger1"
+    elseif input == "Tdagger_1"
         return QCO.kron_single_gate(num_qubits, QCO.TdaggerGate(), "q1")
 
-    elseif input == "Tdagger2"
+    elseif input == "Tdagger_2"
         return QCO.kron_single_gate(num_qubits, QCO.TdaggerGate(), "q2")   
 
-    elseif input == "S1"
+    elseif input == "S_1"
         return QCO.kron_single_gate(num_qubits, QCO.SGate(), "q1") 
 
-    elseif input == "S2"
+    elseif input == "S_2"
         return QCO.kron_single_gate(num_qubits, QCO.SGate(), "q2")  
 
-    elseif input == "Sdagger1"
+    elseif input == "Sdagger_1"
         return QCO.kron_single_gate(num_qubits, QCO.SdaggerGate(), "q1") 
 
-    elseif input == "Sdagger2"
+    elseif input == "Sdagger_2"
         return QCO.kron_single_gate(num_qubits, QCO.SdaggerGate(), "q2")   
 
-    elseif input == "SX1"
+    elseif input == "SX_1"
         return QCO.kron_single_gate(num_qubits, QCO.SXGate(), "q1") 
 
-    elseif input == "SX2"
+    elseif input == "SX_2"
         return QCO.kron_single_gate(num_qubits, QCO.SXGate(), "q2")  
 
-    elseif input == "SXdagger1"
+    elseif input == "SXdagger_1"
         return QCO.kron_single_gate(num_qubits, QCO.SXdaggerGate(), "q1")
 
-    elseif input == "SXdagger2"
+    elseif input == "SXdagger_2"
         return QCO.kron_single_gate(num_qubits, QCO.SXdaggerGate(), "q2")   
 
-    elseif input == "X1"
+    elseif input == "X_1"
         return QCO.kron_single_gate(num_qubits, QCO.XGate(), "q1") 
 
-    elseif input == "X2"
+    elseif input == "X_2"
         return QCO.kron_single_gate(num_qubits, QCO.XGate(), "q2")    
 
-    elseif input == "Y1"
+    elseif input == "Y_1"
         return QCO.kron_single_gate(num_qubits, QCO.YGate(), "q1")  
 
-    elseif input == "Y2"
+    elseif input == "Y_2"
         return QCO.kron_single_gate(num_qubits, QCO.YGate(), "q2")   
 
-    elseif input == "Z1"
+    elseif input == "Z_1"
         return QCO.kron_single_gate(num_qubits, QCO.ZGate(), "q1") 
 
-    elseif input == "Z2"
+    elseif input == "Z_2"
         return QCO.kron_single_gate(num_qubits, QCO.ZGate(), "q2")     
 
     # Gates with continuous angle parameters
@@ -538,7 +538,7 @@ function get_full_sized_gate(input::String, num_qubits::Int64; matrix = nothing,
         elseif input == "cnot_swap"
             return QCO.CNotGate() * QCO.CNotRevGate()
 
-        elseif input == "H1⊗H2"
+        elseif input == "H_1⊗H_2"
             return kron(QCO.HGate(), QCO.HGate())   
             
         elseif input == "CZ_12"
@@ -577,34 +577,34 @@ function get_full_sized_gate(input::String, num_qubits::Int64; matrix = nothing,
     # All 3-qubit full-sized gates
     if num_qubits == 3
         
-        if input == "H3"
+        if input == "H_3"
             return QCO.kron_single_gate(num_qubits, QCO.HGate(), "q3")
     
-        elseif input == "T3"
+        elseif input == "T_3"
             return QCO.kron_single_gate(num_qubits, QCO.TGate(), "q3")
     
-        elseif input == "Tdagger3"
+        elseif input == "Tdagger_3"
             return QCO.kron_single_gate(num_qubits, QCO.TdaggerGate(), "q3")   
     
-        elseif input == "S3"
+        elseif input == "S_3"
             return QCO.kron_single_gate(num_qubits, QCO.SGate(), "q3") 
     
-        elseif input == "Sdagger3"
+        elseif input == "Sdagger_3"
             return QCO.kron_single_gate(num_qubits, QCO.SdaggerGate(), "q3") 
     
-        elseif input == "SX3"
+        elseif input == "SX_3"
             return QCO.kron_single_gate(num_qubits, QCO.SXGate(), "q3") 
     
-        elseif input == "SXdagger3"
+        elseif input == "SXdagger_3"
             return QCO.kron_single_gate(num_qubits, QCO.SXdaggerGate(), "q3")
     
-        elseif input == "X3"
+        elseif input == "X_3"
             return QCO.kron_single_gate(num_qubits, QCO.XGate(), "q3") 
     
-        elseif input == "Y3"
+        elseif input == "Y_3"
             return QCO.kron_single_gate(num_qubits, QCO.YGate(), "q3")  
      
-        elseif input == "Z3"
+        elseif input == "Z_3"
             return QCO.kron_single_gate(num_qubits, QCO.ZGate(), "q3") 
      
         # Gates with continuous angle parameters

--- a/test/data_tests.jl
+++ b/test/data_tests.jl
@@ -34,7 +34,7 @@ end
     params = Dict{String, Any}(
     "num_qubits" => 2,
     "depth" => 2,
-    "elementary_gates" => ["T1", "T2", "Tdagger1", "Tdagger2", "S1", "S2", "Sdagger1", "Sdagger2", "SX1", "SX2", "SXdagger1", "SXdagger2", "X1", "X2", "Y1", "Y2", "Z1", "Z2", "cnot_swap", "H1⊗H2", "CZ_12", "CH_12", "CV_12", "swap", "M_12", "QFT_12", "CSX_12", "W_12", "HCoin"],
+    "elementary_gates" => ["T_1", "T_2", "Tdagger_1", "Tdagger_2", "S_1", "S_2", "Sdagger_1", "Sdagger_2", "SX_1", "SX_2", "SXdagger_1", "SXdagger_2", "X_1", "X_2", "Y_1", "Y_2", "Z_1", "Z_2", "cnot_swap", "H_1⊗H_2", "CZ_12", "CH_12", "CV_12", "swap", "M_12", "QFT_12", "CSX_12", "W_12", "HCoin"],
     "target_gate" => QCO.IGate(2),               
     )
 
@@ -45,7 +45,7 @@ end
     params = Dict{String, Any}(
     "num_qubits" => 3,
     "depth" => 2,
-    "elementary_gates" => ["H3", "T3", "Tdagger3", "Sdagger3", "SX3", "SXdagger3", "X3", "Y3", "Z3", "toffoli", "CSwap", "CCZ", "peres", "cnot_12", "cnot_23", "cnot_21", "cnot_32", "cnot_13", "cnot_31"],
+    "elementary_gates" => ["H_3", "T_3", "Tdagger_3", "Sdagger_3", "SX_3", "SXdagger_3", "X_3", "Y_3", "Z_3", "toffoli", "CSwap", "CCZ", "peres", "cnot_12", "cnot_23", "cnot_21", "cnot_32", "cnot_13", "cnot_31"],
     "target_gate" => QCO.IGate(3)
     )
 
@@ -58,16 +58,16 @@ end
     function input_circuit_1()
         # [(depth, gate)]
         return [(1, "cnot_21"), 
-                (2, "S1"), 
-                (3, "H2"), 
-                (4, "S2")
+                (2, "S_1"), 
+                (3, "H_2"), 
+                (4, "S_2")
                 ]
     end
 
     params = Dict{String, Any}(
     "num_qubits" => 2,
     "depth" => 5,
-    "elementary_gates" => ["S1", "S2", "H1", "H2", "cnot_12", "cnot_21", "Identity"], 
+    "elementary_gates" => ["S_1", "S_2", "H_1", "H_2", "cnot_12", "cnot_21", "Identity"], 
     "target_gate" => QCO.MGate(),
     "input_circuit" => input_circuit_1(),
     )
@@ -78,18 +78,18 @@ end
     @test data["input_circuit"]["1"]["depth"] == 1
     @test data["input_circuit"]["1"]["gate"] == "cnot_21"
     @test data["input_circuit"]["2"]["depth"] == 2
-    @test data["input_circuit"]["2"]["gate"] == "S1"
+    @test data["input_circuit"]["2"]["gate"] == "S_1"
     @test data["input_circuit"]["3"]["depth"] == 3
-    @test data["input_circuit"]["3"]["gate"] == "H2"
+    @test data["input_circuit"]["3"]["gate"] == "H_2"
     @test data["input_circuit"]["4"]["depth"] == 4
-    @test data["input_circuit"]["4"]["gate"] == "S2"
+    @test data["input_circuit"]["4"]["gate"] == "S_2"
 
     function input_circuit_2()
         # [(depth, gate)]
         return [(1, "cnot_21"), 
-                (2, "S1"), 
-                (3, "H2"), 
-                (4, "T1")
+                (2, "S_1"), 
+                (3, "H_2"), 
+                (4, "T_1")
                 ]
     end
 
@@ -100,9 +100,9 @@ end
     function input_circuit_3()
         # [(depth, gate)]
         return [(1, "cnot_21"), 
-                (2, "S1"), 
-                (2, "H2"), 
-                (4, "S2")
+                (2, "S_1"), 
+                (2, "H_2"), 
+                (4, "S_2")
                 ]
     end
 
@@ -113,11 +113,11 @@ end
     function input_circuit_4()
         # [(depth, gate)]
         return [(1, "cnot_21"), 
-                (2, "S1"), 
-                (3, "H2"), 
-                (4, "S2"),
+                (2, "S_1"), 
+                (3, "H_2"), 
+                (4, "S_2"),
                 (5, "Identity"),
-                (6, "S1"),
+                (6, "S_1"),
                 ]
     end
 

--- a/test/gates_tests.jl
+++ b/test/gates_tests.jl
@@ -40,16 +40,16 @@
     @test isapprox(QCO.MGate(), QCO.CNotRevGate() * H2 * S1_S2)
 
     @test isapprox(QCO.NegIGate(), kron(QCO.RZGate(2*π), QCO.IGate(1)), atol = tol_0)
-    Z1 = QCO.get_full_sized_gate("Z1", 2);
-    Z2 = QCO.get_full_sized_gate("Z2", 2);
-    T2 = QCO.get_full_sized_gate("T2", 2);
-    Y2 = QCO.get_full_sized_gate("Y2", 2);
+    Z1 = QCO.get_full_sized_gate("Z_1", 2);
+    Z2 = QCO.get_full_sized_gate("Z_2", 2);
+    T2 = QCO.get_full_sized_gate("T_2", 2);
+    Y2 = QCO.get_full_sized_gate("Y_2", 2);
     cnot_12 = QCO.get_full_sized_gate("cnot_12", 2);
     cnot_21 = QCO.get_full_sized_gate("cnot_21", 2);
-    Sdagger1 = QCO.get_full_sized_gate("Sdagger1", 2);
-    Tdagger1 = QCO.get_full_sized_gate("Tdagger1", 2);
-    SX1 = QCO.get_full_sized_gate("SX1", 2);
-    SXdagger2 = QCO.get_full_sized_gate("SXdagger2", 2);
+    Sdagger1 = QCO.get_full_sized_gate("Sdagger_1", 2);
+    Tdagger1 = QCO.get_full_sized_gate("Tdagger_1", 2);
+    SX1 = QCO.get_full_sized_gate("SX_1", 2);
+    SXdagger2 = QCO.get_full_sized_gate("SXdagger_2", 2);
     @test isapprox(-QCO.HCoinGate(), Z2 * cnot_21 * SXdagger2 * Y2 * cnot_21 * Tdagger1 * Z1 * T2 * Sdagger1 * cnot_12 * Sdagger1 * SX1 * cnot_21 * cnot_12, atol = tol_0)
 
     CV_23 = QCO.get_full_sized_gate("CV_23", 3);
@@ -62,9 +62,9 @@
     CVdagger_31 = QCO.get_full_sized_gate("CVdagger_31", 3);
     @test isapprox(QCO.IGate(3), CVdagger_12 * CVdagger_12 * CVdagger_12 * CVdagger_12 * CVdagger_31 * CVdagger_31 * CVdagger_31 * CVdagger_31, atol = tol_0)
 
-    H2 = QCO.get_full_sized_gate("H2", 2);
-    T1 = QCO.get_full_sized_gate("T1", 2);
-    Tdagger2 = QCO.get_full_sized_gate("Tdagger2", 2);
+    H2 = QCO.get_full_sized_gate("H_2", 2);
+    T1 = QCO.get_full_sized_gate("T_1", 2);
+    Tdagger2 = QCO.get_full_sized_gate("Tdagger_2", 2);
     @test isapprox(QCO.CVdaggerGate(), H2 * Tdagger1 * cnot_21 * T1 * Tdagger2 * cnot_21 * H2, atol = tol_0)
 
     cnot_12 = QCO.get_full_sized_gate("cnot_12", 2);

--- a/test/qc_model_tests.jl
+++ b/test/qc_model_tests.jl
@@ -3,7 +3,7 @@
     params = Dict{String, Any}(
     "num_qubits" => 2, 
     "depth" => 5,
-    "elementary_gates" => ["H1", "H2", "cnot_12", "Identity"],  
+    "elementary_gates" => ["H_1", "H_2", "cnot_12", "Identity"],  
     "target_gate" => QCO.CNotRevGate(),
     "objective" => "minimize_depth", 
     "decomposition_type" => "exact"
@@ -125,7 +125,7 @@ end
     params = Dict{String, Any}(
         "num_qubits" => 2, 
         "depth" => 3,    
-        "elementary_gates" => ["H1", "H2"],  
+        "elementary_gates" => ["H_1", "H_2"],  
         "target_gate" => QCO.kron_single_gate(2, QCO.HGate(), "q1"),
         "objective" => "minimize_depth", 
         "decomposition_type" => "exact"
@@ -137,7 +137,7 @@ end
     data = QCO.get_data(params)
 
     for i in keys(data["gates_dict"])
-        if data["gates_dict"][i]["type"] == "H1"
+        if data["gates_dict"][i]["type"] == "H_1"
             @test isapprox(sum(result_qc["solution"]["z_onoff_var"][parse(Int64, i),:]), 3 , atol = tol_0)
         end
     end
@@ -148,16 +148,16 @@ end
     function input_circuit()
         # [(depth, gate)]
         return [(1, "cnot_21"), 
-                (2, "S1"), 
-                (3, "H2"), 
-                (4, "S2")
+                (2, "S_1"), 
+                (3, "H_2"), 
+                (4, "S_2")
                 ]
     end
 
     params = Dict{String, Any}(
     "num_qubits" => 2,
     "depth" => 4,
-    "elementary_gates" => ["S1", "S2", "H1", "H2", "cnot_12", "cnot_21", "Identity"], 
+    "elementary_gates" => ["S_1", "S_2", "H_1", "H_2", "cnot_12", "cnot_21", "Identity"], 
     "target_gate" => QCO.MGate(),
     "input_circuit" => input_circuit(),
     "objective" => "minimize_depth", 
@@ -177,7 +177,7 @@ end
     params = Dict{String, Any}(
     "num_qubits" => 2,
     "depth" => 4,
-    "elementary_gates" => ["S1", "S2", "H1", "H2", "cnot_12", "cnot_21", "Identity"], 
+    "elementary_gates" => ["S_1", "S_2", "H_1", "H_2", "cnot_12", "cnot_21", "Identity"], 
     "target_gate" => QCO.MGate(),
     "objective" => "minimize_depth", 
     "decomposition_type" => "exact"
@@ -191,7 +191,7 @@ end
             num_involutory_matrices += 1
         end
 
-        if ("S1" in gates_dict[i]["type"]) || ("S2" in gates_dict[i]["type"])
+        if ("S_1" in gates_dict[i]["type"]) || ("S_2" in gates_dict[i]["type"])
             @test !(gates_dict[i]["isInvolutory"])
         end
     end
@@ -209,7 +209,7 @@ end
     params = Dict{String, Any}(
     "num_qubits" => 2,
     "depth" => 5,
-    "elementary_gates" => ["S1", "S2", "H1", "H2", "cnot_12", "cnot_21", "Identity"], 
+    "elementary_gates" => ["S_1", "S_2", "H_1", "H_2", "cnot_12", "cnot_21", "Identity"], 
     "target_gate" => QCO.MGate(),
     "objective" => "minimize_depth", 
     "decomposition_type" => "exact",

--- a/test/types_tests.jl
+++ b/test/types_tests.jl
@@ -1,7 +1,7 @@
 @testset "types testing" begin
-    gate = QCO.GateData("H1", 2)
+    gate = QCO.GateData("H_1", 2)
     @test gate.isreal
-    gate = QCO.GateData("S3", 3)
+    gate = QCO.GateData("S_3", 3)
     @test !gate.isreal
 
     # Add more tests for U3 and R gates.

--- a/test/utility_tests.jl
+++ b/test/utility_tests.jl
@@ -72,7 +72,7 @@ end
        "num_qubits" => 2, 
        "depth" => 5,    
 
-       "elementary_gates" => ["H1", "H2", "cnot_12", "Identity"],  
+       "elementary_gates" => ["H_1", "H_2", "cnot_12", "Identity"],  
        "target_gate" => QCO.CNotRevGate()
        )
     
@@ -96,7 +96,7 @@ end
     params = Dict{String, Any}(
         "num_qubits" => 3, 
         "depth" => 15,    
-        "elementary_gates" => ["T1", "T2", "T3", "H3", "cnot_12", "cnot_13", "cnot_23", "Tdagger2", "Tdagger3", "Identity"], 
+        "elementary_gates" => ["T_1", "T_2", "T_3", "H_3", "cnot_12", "cnot_13", "cnot_23", "Tdagger_2", "Tdagger_3", "Identity"], 
         "target_gate" => QCO.ToffoliGate()
         )
     data = QCO.get_data(params)
@@ -109,15 +109,15 @@ end
     params = Dict{String, Any}(
         "num_qubits" => 2, 
         "depth" => 14,    
-        "elementary_gates" => ["Y1", "Y2", "Z1", "Z2", "T2", "Tdagger1", "Sdagger1", "SX1", "SXdagger2", "cnot_21", "cnot_12", "Identity"], 
+        "elementary_gates" => ["Y_1", "Y_2", "Z_1", "Z_2", "T_2", "Tdagger_1", "Sdagger_1", "SX_1", "SXdagger_2", "cnot_21", "cnot_12", "Identity"], 
         "target_gate" => -QCO.HCoinGate())
     data = QCO.get_data(params)
     idempotent_gates = QCO.get_idempotent_gates(data["gates_dict"])
     @test idempotent_gates[1] == 6
     @test idempotent_gates[2] == 7
-    @test "Tdagger1" in data["gates_dict"]["$(idempotent_gates[1])"]["type"]
-    @test "Sdagger1" in data["gates_dict"]["$(idempotent_gates[2])"]["type"]
-    @test "Z1" in data["gates_dict"]["3"]["type"]
+    @test "Tdagger_1" in data["gates_dict"]["$(idempotent_gates[1])"]["type"]
+    @test "Sdagger_1" in data["gates_dict"]["$(idempotent_gates[2])"]["type"]
+    @test "Z_1" in data["gates_dict"]["3"]["type"]
     
     M1 = data["gates_dict"]["$(idempotent_gates[1])"]["matrix"]
     M2 = data["gates_dict"]["$(idempotent_gates[2])"]["matrix"]


### PR DESCRIPTION
Issue https://github.com/harshangrjn/QuantumCircuitOpt.jl/issues/13 : now all single qubit gates follow the naming scheme "GATE_QUBIT" instead of "GATEQUBIT". This is not applied to rotation gates. A few updates in data.jl was mostly it. Then updating the examples and tests. All examples and tests passed locally on my computer. I checked for all the old nomenclature and didn't see any left, but if there are any spots with it let me know. 