### PR TITLE
Adding gate specificity to rotation gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ end
 params = Dict{String, Any}(
 "num_qubits" => 2, 
 "depth" => 3,    
-"elementary_gates" => ["U3", "CNot_12", "Identity"], 
+"elementary_gates" => ["U3_2", "CNot_12", "Identity"], 
 "target_gate" => target_gate(),
        
 "U_θ_discretization" => collect(-π/2:π/2:π/2),

--- a/docs/src/quickguide.md
+++ b/docs/src/quickguide.md
@@ -49,7 +49,7 @@ end
 params = Dict{String, Any}(
 "num_qubits" => 2, 
 "depth" => 3,    
-"elementary_gates" => ["U3", "CNot_12", "Identity"], 
+"elementary_gates" => ["U3_2", "CNot_12", "Identity"], 
 "target_gate" => target_gate(),
        
 "U_θ_discretization" => [-π/2, 0, π/2],
@@ -97,7 +97,7 @@ Quantum Circuit Model Data
   Number of qubits: 2
   Total number of elementary gates (including discretization): 36
   Maximum depth of decomposition: 3
-  Input elementary gates: ["U3", "CNot_12", "Identity"]
+  Input elementary gates: ["U3_2", "CNot_12", "Identity"]
     U3 gate - θ discretization: [-90.0, 0.0, 90.0]
     U3 gate - ϕ discretization: [-90.0, 0.0, 90.0]
     U3 gate - λ discretization: [-90.0, 0.0, 90.0]

--- a/examples/2qubit_gates.jl
+++ b/examples/2qubit_gates.jl
@@ -7,7 +7,7 @@ function decompose_hadamard()
     "num_qubits" => 2, 
     "depth" => 3,    
 
-    "elementary_gates" => ["U3", "CNot_12", "Identity"], 
+    "elementary_gates" => ["U3_1", "CNot_12", "Identity"], 
     "target_gate" => QCO.kron_single_gate(2, QCO.HGate(), "q1"),
        
     "U_θ_discretization" => [0, π/2],
@@ -35,7 +35,7 @@ function decompose_controlled_Z()
     "num_qubits" => 2, 
     "depth" => 4,    
 
-    "elementary_gates" => ["U3", "CNot_12", "Identity"], 
+    "elementary_gates" => ["U3_2", "CNot_12", "Identity"], 
     "target_gate" => QCO.CZGate(),
        
     "U_θ_discretization" => [-π/2, 0, π/2],
@@ -86,7 +86,7 @@ function decompose_controlled_H()
     "num_qubits" => 2, 
     "depth" => 5,    
 
-    "elementary_gates" => ["U3", "CNot_12", "Identity"], 
+    "elementary_gates" => ["U3_2", "CNot_12", "Identity"], 
     "target_gate" => QCO.CHGate(),
 
     "U_θ_discretization" => [-π/4, 0, π/4],
@@ -114,7 +114,7 @@ function decompose_controlled_H_with_R()
     "num_qubits" => 2, 
     "depth" => 5,    
 
-    "elementary_gates" => ["RY", "CNot_12", "Identity"], 
+    "elementary_gates" => ["RY_1", "RY_2", "CNot_12", "Identity"], 
     "target_gate" => QCO.CHGate(),
        
     "RX_discretization" => [], 
@@ -141,7 +141,7 @@ function decompose_magic_M()
         "num_qubits" => 2, 
         "depth" => 5,    
     
-        "elementary_gates" => ["U3", "CNot_12", "CNot_21", "Identity"], 
+        "elementary_gates" => ["U3_1", "U3_2", "CNot_12", "CNot_21", "Identity"], 
         "target_gate" => QCO.MGate(),   
            
         "U_θ_discretization" => [0, π/2],
@@ -191,7 +191,7 @@ function decompose_S()
         "num_qubits" => 2, 
         "depth" => 3,    
     
-        "elementary_gates" => ["U3", "CNot_12", "Identity"], 
+        "elementary_gates" => ["U3_1", "U3_2", "CNot_12", "Identity"], 
         "target_gate" => QCO.kron_single_gate(2, QCO.SGate(), "q1"),
            
         "U_θ_discretization" => [0, π/4, π/2],
@@ -241,7 +241,7 @@ function decompose_cnot_21_with_U()
         "num_qubits" => 2, 
         "depth" => 6,    
     
-        "elementary_gates" => ["U3", "CNot_12", "Identity"], 
+        "elementary_gates" => ["U3_1", "U3_2", "CNot_12", "Identity"], 
         "target_gate" => QCO.CNotRevGate(),   
            
         "U_θ_discretization" => [-π/2, π/2],
@@ -291,7 +291,7 @@ function decompose_W()
         "num_qubits" => 2, 
         "depth" => 5,    
     
-        "elementary_gates" => ["U3", "CNot_21", "CNot_12", "Identity"], 
+        "elementary_gates" => ["U3_1", "U3_2", "CNot_21", "CNot_12", "Identity"], 
         "target_gate" => QCO.WGate(),   
 
         "U_θ_discretization" => [-π/4, π/4],

--- a/examples/3qubit_gates.jl
+++ b/examples/3qubit_gates.jl
@@ -7,7 +7,7 @@ function decompose_RX_on_q3()
     "num_qubits" => 3, 
     "depth" => 3,    
 
-    "elementary_gates" => ["U3", "Identity"], 
+    "elementary_gates" => ["U3_3", "Identity"], 
     "target_gate" => QCO.kron_single_gate(3, QCO.RXGate(π/4), "q3"),
        
     "U_θ_discretization" => [0, π/4],

--- a/examples/ex1.jl
+++ b/examples/ex1.jl
@@ -37,7 +37,7 @@ params = Dict{String, Any}(
 "num_qubits" => 2,
 "depth" => 4,
 
-"elementary_gates" => ["U3", "CNot_12", "Identity"],
+"elementary_gates" => ["U3_2", "CNot_12", "Identity"],
 # "elementary_gates" => ["T_1", "T_2", "T_3", "H_3", "CNot_12", "CNot_13", "CNot_23", "Tdagger_2", "Tdagger_3", "Identity"],
 # "elementary_gates" => ["S_1", "S_2", "H_1", "H_2", "CNot_12", "CNot_21", "Identity"],
 

--- a/src/data.jl
+++ b/src/data.jl
@@ -121,11 +121,11 @@ function get_data(params::Dict{String, Any}; eliminate_identical_gates = true)
 
     if !isempty(R_gates_ids) 
         for i in R_gates_ids
-            if data["elementary_gates"][i] == "RX"
+            if data["elementary_gates"][i][1:2] == "RX"
                 data["discretization"]["RX"] = params["RX_discretization"]
-            elseif data["elementary_gates"][i] == "RY"
+            elseif data["elementary_gates"][i][1:2] == "RY"
                 data["discretization"]["RY"] = params["RY_discretization"]
-            elseif data["elementary_gates"][i] == "RZ"
+            elseif data["elementary_gates"][i][1:2] == "RZ"
                 data["discretization"]["RZ"] = params["RZ_discretization"]
             end
         end
@@ -133,7 +133,7 @@ function get_data(params::Dict{String, Any}; eliminate_identical_gates = true)
 
     if !isempty(U_gates_ids)
         for i in U_gates_ids
-            if data["elementary_gates"][i] == "U3"
+            if data["elementary_gates"][i][1:2] == "U3"
                 data["discretization"]["U3_θ"] = params["U_θ_discretization"]
                 data["discretization"]["U3_ϕ"] = params["U_ϕ_discretization"]
                 data["discretization"]["U3_λ"] = params["U_λ_discretization"]
@@ -290,10 +290,10 @@ function get_all_gates_dictionary(params::Dict{String, Any}, elementary_gates::A
                 M_elementary_dict = U_complex_dict
             end
 
-            for j in keys(M_elementary_dict)
+            for j in keys(M_elementary_dict) # Gate type
                 if (j == elementary_gates[i])
-                    for k in keys(M_elementary_dict[j])
-                        for l in keys(M_elementary_dict[j][k]["$(num_qubits)qubit_rep"])
+                    for k in keys(M_elementary_dict[j]) # Angle
+                        for l in keys(M_elementary_dict[j][k]["$(num_qubits)qubit_rep"]) # qubits (which will now be 1)
                             
                             M_sqrd = M_elementary_dict[j][k]["$(num_qubits)qubit_rep"][l]^2
 
@@ -348,16 +348,17 @@ function get_all_R_gates(params::Dict{String, Any}, elementary_gates::Array{Stri
 
             gate_type = elementary_gates[R_gates_ids[i]]
 
-            if !(gate_type in ["RX", "RY", "RZ"])
+            if !(gate_type in ["RX_1", "RX_2", "RX_3", "RY_1", "RY_2", "RY_3", "RZ_1", "RZ_2", "RZ_3"])
                 Memento.error(_LOGGER, "Input R gate type ($(gate_type)) is not supported.")
             end
-
-            if isempty(params[string(gate_type,"_discretization")])
+            
+            # This means that discretizations are the same for all gates, checks only for RX/RY/RZ discretization
+            if isempty(params[string(gate_type[1:2],"_discretization")])
                 Memento.error(_LOGGER, "No discretized angle was specified for $(gate_type) gate. Input at least one angle")
             end        
 
             R_complex["$(gate_type)"] = Dict{String, Any}()    
-            R_complex["$(gate_type)"] = QCO.get_discretized_R_gates(gate_type, R_complex[gate_type], collect(params[string(gate_type,"_discretization")]), params["num_qubits"])
+            R_complex["$(gate_type)"] = QCO.get_discretized_R_gates(gate_type, R_complex[gate_type], collect(params[string(gate_type[1:2],"_discretization")]), params["num_qubits"])
 
         end
     end
@@ -365,12 +366,14 @@ function get_all_R_gates(params::Dict{String, Any}, elementary_gates::Array{Stri
     return R_complex    
 end
 
-function get_discretized_R_gates(R_type::String, R::Dict{String, Any}, discretization::Array{Float64,1}, num_qubits::Int64)
+function get_discretized_R_gates(Gate_type::String, R::Dict{String, Any}, discretization::Array{Float64,1}, num_qubits::Int64)
+
+    R_type = Gate_type[1:2]
 
     if length(discretization) >= 1
 
         for i=1:length(discretization)
-            if     R_type == "RX"
+            if R_type == "RX"
                 R_discrete = QCO.RXGate(discretization[i])
             elseif R_type == "RY"
                 R_discrete = QCO.RYGate(discretization[i])
@@ -383,9 +386,7 @@ function get_discretized_R_gates(R_type::String, R::Dict{String, Any}, discretiz
                                              "$(num_qubits)qubit_rep" => Dict{String, Any}()
                                             )
             
-            for i_qu = 1:num_qubits
-                R["angle_$i"]["$(num_qubits)qubit_rep"]["qubit_$i_qu"] = QCO.get_full_sized_gate(R_type, num_qubits, matrix = R_discrete, qubit_location = "q$i_qu")
-            end
+            R["angle_$i"]["$(num_qubits)qubit_rep"]["qubit_$(Gate_type[4])"] = QCO.get_full_sized_gate(R_type, num_qubits, matrix = R_discrete, qubit_location = "q$(Gate_type[4])")
 
         end
     end 
@@ -401,10 +402,10 @@ function get_all_U_gates(params::Dict{String, Any}, elementary_gates::Array{Stri
 
     if length(U_gates_ids) >= 1 
         for i=1:length(U_gates_ids)
-
-            if (elementary_gates[U_gates_ids[i]] == "U3")        
-                U_complex["U3"] = Dict{String, Any}()    
-                U_complex["U3"] = QCO.get_discretized_U3_gates("U3", U_complex["U3"], collect(float(params["U_θ_discretization"])), collect(float(params["U_ϕ_discretization"])), collect(float(params["U_λ_discretization"])), params["num_qubits"])
+            gate_name = elementary_gates[U_gates_ids[i]]
+            if (gate_name[1:2] == "U3")        
+                U_complex[gate_name] = Dict{String, Any}()    
+                U_complex[gate_name] = QCO.get_discretized_U3_gates(gate_name, U_complex[gate_name], collect(float(params["U_θ_discretization"])), collect(float(params["U_ϕ_discretization"])), collect(float(params["U_λ_discretization"])), params["num_qubits"])
             end
 
             # Add support for U1 and U2 universal gates here
@@ -415,9 +416,11 @@ function get_all_U_gates(params::Dict{String, Any}, elementary_gates::Array{Stri
     return U_complex    
 end
 
-function get_discretized_U3_gates(U_type::String, U::Dict{String, Any}, θ_discretization::Array{Float64,1}, ϕ_discretization::Array{Float64,1}, λ_discretization::Array{Float64,1}, num_qubits::Int64)
+function get_discretized_U3_gates(Gate_type::String, U::Dict{String, Any}, θ_discretization::Array{Float64,1}, ϕ_discretization::Array{Float64,1}, λ_discretization::Array{Float64,1}, num_qubits::Int64)
     
     counter = 1 
+
+    U_type = Gate_type[1:2]
 
     for i=1:length(θ_discretization)
         for j=1:length(ϕ_discretization)
@@ -432,9 +435,7 @@ function get_discretized_U3_gates(U_type::String, U::Dict{String, Any}, θ_discr
                                                           "$(num_qubits)qubit_rep" => Dict{String, Any}()
                                                          )
                 
-                for i_qu=1:num_qubits
-                    U["angle_$(counter)"]["$(num_qubits)qubit_rep"]["qubit_$i_qu"] = QCO.get_full_sized_gate(U_type, num_qubits, matrix = U_discrete, qubit_location = "q$i_qu")
-                end
+                U["angle_$(counter)"]["$(num_qubits)qubit_rep"]["qubit_$(Gate_type[4])"] = QCO.get_full_sized_gate(U_type, num_qubits, matrix = U_discrete, qubit_location = "q$(Gate_type[4])")
 
                 counter += 1
             end

--- a/src/log.jl
+++ b/src/log.jl
@@ -48,11 +48,11 @@ function visualize_solution(results::Dict{String, Any}, data::Dict{String, Any};
 
             for i in R_gates_ids
 
-                if data["elementary_gates"][i] == "RX"
+                if data["elementary_gates"][i][1:2] == "RX"
                     printstyled("    ","RX gate discretization: ", ceil.(rad2deg.(data["discretization"]["RX"]), digits = 1),"\n"; color = :cyan)
-                elseif data["elementary_gates"][i] == "RY"
+                elseif data["elementary_gates"][i][1:2] == "RY"
                     printstyled("    ","RY gate discretization: ", ceil.(rad2deg.(data["discretization"]["RY"]), digits = 1),"\n"; color = :cyan)
-                elseif data["elementary_gates"][i] == "RZ"
+                elseif data["elementary_gates"][i][1:2] == "RZ"
                     printstyled("    ","RZ gate discretization: ", ceil.(rad2deg.(data["discretization"]["RZ"]), digits = 1),"\n"; color = :cyan)
                 end
 
@@ -64,7 +64,7 @@ function visualize_solution(results::Dict{String, Any}, data::Dict{String, Any};
 
             for i in U_gates_ids
 
-                if data["elementary_gates"][i] == "U3"
+                if data["elementary_gates"][i][1:2] == "U3"
                     printstyled("    ","U3 gate - θ discretization: ", ceil.(rad2deg.(data["discretization"]["U3_θ"]), digits = 1),"\n"; color = :cyan)
                     printstyled("    ","U3 gate - ϕ discretization: ", ceil.(rad2deg.(data["discretization"]["U3_ϕ"]), digits = 1),"\n"; color = :cyan)
                     printstyled("    ","U3 gate - λ discretization: ", ceil.(rad2deg.(data["discretization"]["U3_λ"]), digits = 1),"\n"; color = :cyan)

--- a/test/qc_model_tests.jl
+++ b/test/qc_model_tests.jl
@@ -47,7 +47,7 @@ end
     params = Dict{String, Any}(
     "num_qubits" => 2, 
     "depth" => 3,    
-    "elementary_gates" => ["U3", "Identity"],  
+    "elementary_gates" => ["U3_1", "Identity"],  
     "target_gate" => QCO.kron_single_gate(2, QCO.U3Gate(0,0,π/4), "q1"),
     "U_θ_discretization" => [0, π/2],
     "U_ϕ_discretization" => [0],
@@ -74,7 +74,7 @@ end
     params = Dict{String, Any}(
     "num_qubits" => 2, 
     "depth" => 3,
-    "elementary_gates" => ["RX", "RY", "RZ", "Identity"],  
+    "elementary_gates" => ["RX_1", "RY_2", "RZ_1", "Identity"],  
     "target_gate" => QCO.kron_single_gate(2, QCO.RXGate(π/4), "q1") * QCO.kron_single_gate(2, QCO.RYGate(π/4), "q2") * QCO.kron_single_gate(2, QCO.RZGate(π/4), "q1"),
     "RX_discretization" => [0, π/4],
     "RY_discretization" => [π/4],
@@ -96,7 +96,7 @@ end
     params = Dict{String, Any}(
     "num_qubits" => 3, 
     "depth" => 2,    
-    "elementary_gates" => ["U3", "Identity"],  
+    "elementary_gates" => ["U3_3", "Identity"],  
     "target_gate" => QCO.kron_single_gate(3, QCO.RXGate(π/4), "q3"),
     "U_θ_discretization" => [0, π/4],
     "U_ϕ_discretization" => [0, -π/2],
@@ -233,7 +233,7 @@ end
     params = Dict{String, Any}(
                "num_qubits" => 2, 
                "depth" => 2,    
-               "elementary_gates" => ["U3", "Identity"], 
+               "elementary_gates" => ["U3_1", "U3_2", "Identity"], 
                "target_gate" => target_gate(),   
                "U_θ_discretization" => [0, π/2],
                "U_ϕ_discretization" => [π/2],
@@ -257,7 +257,7 @@ end
     params = Dict{String, Any}(
     "num_qubits" => 2, 
     "depth" => 3,    
-    "elementary_gates" => ["U3", "CNot_12", "Identity"], 
+    "elementary_gates" => ["U3_2", "CNot_12", "Identity"], 
     "target_gate" => QCO.CZGate(),
     "U_θ_discretization" => [-π/2, 0, π/2],
     "U_ϕ_discretization" => [0, π/2],


### PR DESCRIPTION
Running locally I have 2 tests fail (constraint_redundant_gate_product_pairs test,  constraint_idempotent_gates) and 2 tests error (Test: Minimum depth U3(0,0,π/4) gate, Test: 3-qubit RX gate decomposition). I suspect these are because the test checks for things are are now problematic because of the added gates. 