### PR TITLE
Fixed 2 tests

### DIFF
--- a/test/qc_model_tests.jl
+++ b/test/qc_model_tests.jl
@@ -257,7 +257,7 @@ end
     params = Dict{String, Any}(
     "num_qubits" => 2, 
     "depth" => 3,    
-    "elementary_gates" => ["U3_2", "CNot_12", "Identity"], 
+    "elementary_gates" => ["U3_1", "U3_2", "CNot_12", "Identity"],
     "target_gate" => QCO.CZGate(),
     "U_θ_discretization" => [-π/2, 0, π/2],
     "U_ϕ_discretization" => [0, π/2],

--- a/test/qc_model_tests.jl
+++ b/test/qc_model_tests.jl
@@ -96,7 +96,7 @@ end
     params = Dict{String, Any}(
     "num_qubits" => 3, 
     "depth" => 2,    
-    "elementary_gates" => ["U3_3", "Identity"],  
+    "elementary_gates" => ["U3_1", "U3_2", "U3_3", "Identity"],  
     "target_gate" => QCO.kron_single_gate(3, QCO.RXGate(π/4), "q3"),
     "U_θ_discretization" => [0, π/4],
     "U_ϕ_discretization" => [0, -π/2],


### PR DESCRIPTION
2 tests were easy to fix, I didn't change the principle of it, I just made it to include all possible U3 gates (which is what it expected before). The two tests were constraint_idempotent_gates and  Test: 3-qubit RX gate decomposition. The two tests that remain are Test: Minimum depth U3(0,0,π/4) gate with 1 error and constraint_redundant_gate_product_pairs test with 2 fails. 